### PR TITLE
Added client.droplets.listByTag and updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ client.droplets
 
 * `client.droplets.list([page, perPage,] [callback])`
 * `client.droplets.list([queryObject,] [callback])`
+* `client.droplets.listByTag(tag.name, [page, perPage,] [callback])`
 * `client.droplets.get(droplet.id, [callback])`
 * `client.droplets.create(attributes, [callback])`
 * `client.droplets.delete(droplet.id, [callback])`

--- a/lib/digitalocean/droplet.js
+++ b/lib/digitalocean/droplet.js
@@ -18,6 +18,22 @@
       return this.client.get.apply(this.client, ['/droplets', {}].concat(slice.call(params), [200, 'droplets', callback]));
     };
 
+    // tagName, required
+    // page, optional
+    // perPage, optional
+    // callback, optional
+    Droplet.prototype.listByTag = function() {
+      var tag = arguments[0],
+          i,
+          params = 3 <= arguments.length ? slice.call(arguments, 1, i = arguments.length - 1) : (i = 1, []),
+          callback = arguments[i++],
+          page = params[0],
+          perPage = params[1],
+          options = { tag_name: tag, page: page, per_page: perPage };
+
+      return this.client.get.apply(this.client, ['/droplets', {}, options, 200, 'droplets', callback]);
+    };
+
     // attributes, required
     // callback, optional
     Droplet.prototype.create = function(attributes, callback) {


### PR DESCRIPTION
This adds the function `client.droplets.listByTag` and updates documentation to add `client.droplets.listByTag`, as well as fixes the documentation by changing `client.droplets.deleteByTagName` to `client.droplets.deleteByTag`.
