### PR TITLE
Made a correction in the 'Floating IPs resources' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ client.floatingIps
 * `client.floatingIps.delete(floatingIp.ip, [callback])`
 * `client.floatingIps.listActions(floatingIp.ip, [page, perPage], [callback])`
 * `client.floatingIps.listActions(floatingIp.ip, [queryObject], [callback])`
-* `client.floatingIps.getAction(floatingIp.ip, [callback])`
+* `client.floatingIps.getAction(floatingIp.ip, action.id, [callback])`
 
 Methods resulting in an `action`:
 * `client.floatingIps.assign(floatingIp.ip, parametersOrDropletId, [callback])`


### PR DESCRIPTION
'action.id' was left out in the getAction() function as a second parameter. Without the action.id, the function cannot fetch a particular action and it results in a 'resource not found' error.